### PR TITLE
Fix: Menubar is behind native MacOS window controls

### DIFF
--- a/src/lib/components/ui/menubar/menubar.svelte
+++ b/src/lib/components/ui/menubar/menubar.svelte
@@ -49,7 +49,7 @@
   <Wrapper let:platform>
     {@const isMac = platform === 'macOS'}
     <div class='w-full top-0 z-[2000] flex justify-between {draggable} absolute h-8'>
-      <div class='flex gap-1.5 items-end ml-14 {isMac ? '!ml-12' : ''}'>
+      <div class='flex gap-1.5 items-end ms-14 {isMac ? '!ms-20' : ''}'>
         <Button size='icon-sm' variant='ghost' disabled={!hasPrevious} class='p-1 shrink-0 custom-not-draggable text-white' tabindex={-1} on:click={previous}>
           <ArrowLeft strokeWidth='1.2' class='size-5' />
         </Button>


### PR DESCRIPTION
The menu bar is currently partially hidden behind the native MacOS window controls making the usage of the back button really hard. (See the screenshot under "Currently")

This pull request adjusts the left/start margin of the menubar that contains the history controls.
Since I had no idea how to build the actual electron app, I just "guessed" the appropriate margin by putting the app below the browser webapp.
Also, I am not sure if it actually affects all Mac users or only me, since I only have my own device.

Currently:
<img width="445" height="131" alt="image" src="https://github.com/user-attachments/assets/ea436a38-f35d-4ffb-84c2-743091afee3d" />

Comparison:
<img width="161" height="306" alt="image" src="https://github.com/user-attachments/assets/0bb114c2-6a11-4a2b-9048-e6549df58b5b" />

Please hit me up, if I need to change something formally.

Best regards!