### PR TITLE
feat: prevent screenshots from overwriting each other

### DIFF
--- a/src/lib/components/ui/player/util.ts
+++ b/src/lib/components/ui/player/util.ts
@@ -64,7 +64,7 @@ export async function screenshot (video: CanvasImageSource, videoWidth: number, 
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = 'screenshot.png'
+    a.download = 'screenshot_${Date.now()}.png'
     a.click()
     URL.revokeObjectURL(url)
   }

--- a/src/lib/components/ui/player/util.ts
+++ b/src/lib/components/ui/player/util.ts
@@ -64,7 +64,7 @@ export async function screenshot (video: CanvasImageSource, videoWidth: number, 
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = 'screenshot_${Date.now()}.png'
+    a.download = `screenshot_${Date.now()}.png`
     a.click()
     URL.revokeObjectURL(url)
   }


### PR DESCRIPTION
Hi, while collecting screen-caps for my art project I noticed the incredibly useful feature of being able to take screenshots in-app. However, the file name is always the same, leading to overwriting. Because I take a lot of screenshots lately, I came up with a small suggestion regarding the naming of screenshots grabbed by Hayase.

**What**
Add a timestamp to screenshot filenames (`screenshot_174783832123.png` instead of `screenshot.png`).

**Why**
Currently every screenshot overwrites the previous one, so you have to manually edit the name before saving for each subsequent one.

**Change**
One line in `src/lib/components/ui/player/util.ts:67` replaced the hard-coded `screenshot.png` with ``screenshot_${Date.now()}.png``.

**Notes**
They will also be sortable, which is convenient.