### PR TITLE
fix: use theme colors for gradient

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -408,14 +408,14 @@ body:has(.custom-fullscreen)> :not(:has(.custom-fullscreen), .custom-fullscreen)
 
 .custom-bg {
   /* this is very hacky, but removes jagged edges */
-  background: repeating-linear-gradient(40deg, hsla(from var(--border, #111) h s l / 0.27) 0, hsla(from var(--border, #555) h s l / 0.33) 1px, hsla(from var(--border, #555) h s l / 0.33) 5px, hsla(from var(--border, #111) h s l / 0.07) 6px, hsla(from var(--popover, #111) h s l / 0.07) 10px);
+  background: repeating-linear-gradient(40deg, #1114 0, #5554 1px, #5554 5px, #1114 6px, #1114 10px);
   /* repeating-linear-gradient(40deg, #5554 0 5px, #1114 0 10px); */
 }
 
 *:focus-visible,
 [data-input='dpad'] *:focus {
   outline: none;
-  border-image: fill 0 linear-gradient(hsla(from var(--border, #888) h s l / 0.53), hsla(from var(--border, #888) h s l / 0.53));
+  border-image: fill 0 linear-gradient(hsla(from var(--ring, #888) h s l / 0.53), hsla(from var(--ring, #888) h s l / 0.53));
 }
 
 *::-webkit-scrollbar {

--- a/src/app.css
+++ b/src/app.css
@@ -408,14 +408,14 @@ body:has(.custom-fullscreen)> :not(:has(.custom-fullscreen), .custom-fullscreen)
 
 .custom-bg {
   /* this is very hacky, but removes jagged edges */
-  background: repeating-linear-gradient(40deg, #1114 0, #5554 1px, #5554 5px, #1114 6px, #1114 10px);
+  background: repeating-linear-gradient(40deg, hsla(from var(--border, #111) h s l / 0.27) 0, hsla(from var(--border, #555) h s l / 0.33) 1px, hsla(from var(--border, #555) h s l / 0.33) 5px, hsla(from var(--border, #111) h s l / 0.07) 6px, hsla(from var(--popover, #111) h s l / 0.07) 10px);
   /* repeating-linear-gradient(40deg, #5554 0 5px, #1114 0 10px); */
 }
 
 *:focus-visible,
 [data-input='dpad'] *:focus {
   outline: none;
-  border-image: fill 0 linear-gradient(#8885, #8885);
+  border-image: fill 0 linear-gradient(hsla(from var(--border, #888) h s l / 0.53), hsla(from var(--border, #888) h s l / 0.53));
 }
 
 *::-webkit-scrollbar {

--- a/src/lib/components/SearchModal.svelte
+++ b/src/lib/components/SearchModal.svelte
@@ -374,12 +374,3 @@
     {/if}
   </Dialog.Content>
 </Dialog.Root>
-
-<style>
-  .banner {
-    background: linear-gradient(90deg, hsla(from var(--background, #000) h s l / 1) 32%, hsla(from var(--background, #000) h s l / 0.9) 100%);
-  }
-  .banner-2 {
-    background: linear-gradient(hsla(from var(--background, #000) h s l / 0.8) 0%, hsla(from var(--background, #000) h s l / 0.8) 90%, var(--background, #000) 100%);
-  }
-</style>

--- a/src/lib/components/SearchModal.svelte
+++ b/src/lib/components/SearchModal.svelte
@@ -377,9 +377,9 @@
 
 <style>
   .banner {
-    background: linear-gradient(90deg, #000 32%, rgba(0, 0, 0, 0.9) 100%);
+    background: linear-gradient(90deg, hsla(from var(--background, #000) h s l / 1) 32%, hsla(from var(--background, #000) h s l / 0.9) 100%);
   }
   .banner-2 {
-    background: linear-gradient(#000d 0%, #000d 90%, #000 100%);
+    background: linear-gradient(hsla(from var(--background, #000) h s l / 0.8) 0%, hsla(from var(--background, #000) h s l / 0.8) 90%, var(--background, #000) 100%);
   }
 </style>

--- a/src/lib/components/ui/banner/banner-image.svelte
+++ b/src/lib/components/ui/banner/banner-image.svelte
@@ -49,10 +49,10 @@
     left: 0 ; bottom: 0;
     width: 100%;
     height: 100%;
-    background: radial-gradient(75% 65% at 59.18% 34.97%, color-mix(in srgb, var(--background, #000) 16%, transparent) 30.56%, var(--background, #000) 100%);
+    background: radial-gradient(75% 65% at 59.18% 34.97%, hsla(from var(--background, #000) h s l / 0.16) 30.56%, var(--background, #000) 100%);
   }
 
   :global(.banner-gr-sm::after) {
-    background: radial-gradient(75% 65% at 50% 34.97%, color-mix(in srgb, var(--background, #000) 16%, transparent) 30.56%, var(--background, #000) 100%) !important;
+    background: radial-gradient(75% 65% at 50% 34.97%, hsla(from var(--background, #000) h s l / 0.16) 30.56%, var(--background, #000) 100%) !important;
   }
 </style>

--- a/src/lib/components/ui/banner/banner-image.svelte
+++ b/src/lib/components/ui/banner/banner-image.svelte
@@ -49,10 +49,10 @@
     left: 0 ; bottom: 0;
     width: 100%;
     height: 100%;
-    background: radial-gradient(75% 65% at 59.18% 34.97%, rgba(0, 0, 0, 0.16) 30.56%, rgba(0, 0, 0, 1) 100%)
+    background: radial-gradient(75% 65% at 59.18% 34.97%, color-mix(in srgb, var(--background, #000) 16%, transparent) 30.56%, var(--background, #000) 100%);
   }
 
   :global(.banner-gr-sm::after) {
-    background: radial-gradient(75% 65% at 50% 34.97%, rgba(0, 0, 0, 0.16) 30.56%, rgba(0, 0, 0, 1) 100%) !important
+    background: radial-gradient(75% 65% at 50% 34.97%, color-mix(in srgb, var(--background, #000) 16%, transparent) 30.56%, var(--background, #000) 100%) !important;
   }
 </style>

--- a/src/lib/components/ui/cards/preview.svelte
+++ b/src/lib/components/ui/cards/preview.svelte
@@ -80,7 +80,7 @@
     /* when clicking, translate fucks up the position, and video might leak down 1 or 2 pixels, stickig under the gradient, look bad */
     margin-bottom: -2px;
     width: 100%; height: 100% ;
-    background: linear-gradient(180deg, #0000 0%, #0a0a0a00 80%, #0a0a0ae3 95%, #0a0a0a 100%);
+    background: linear-gradient(180deg, hsla(from var(--muted, #000) h s l / 0) 0%, hsla(from var(--muted, #0a0a0a) h s l / 0) 80%, hsla(from var(--muted, #0a0a0a) h s l / 0.89) 95%, var(--muted, #0a0a0a) 100%);
   }
   .absolute-container {
     will-change: transform;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -138,7 +138,7 @@
     top: calc(var(--to-y) * 1px);
     width: calc(var(--to-size) * 2.1px);
     height: calc(var(--to-size) * 1px);
-    background: linear-gradient(to right, hsla(from var(--foreground, #fff) h s l / 1), transparent);
+    background: linear-gradient(to right, #fff, transparent);
     opacity: calc(var(--dist-factor, 0) * var(--spotlight-opacity, 1));
     transform: rotate(var(--to-angle)) perspective(calc(var(--to-size) * 2px)) rotateY(calc(var(--dist-factor) * -50deg - 20deg));
     animation: spotlight-properties .1s ease-out .15s both, spotlight-fade .55s ease-out both;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -138,7 +138,7 @@
     top: calc(var(--to-y) * 1px);
     width: calc(var(--to-size) * 2.1px);
     height: calc(var(--to-size) * 1px);
-    background: linear-gradient(to right, #fff, transparent);
+    background: linear-gradient(to right, hsla(from var(--foreground, #fff) h s l / 1), transparent);
     opacity: calc(var(--dist-factor, 0) * var(--spotlight-opacity, 1));
     transform: rotate(var(--to-angle)) perspective(calc(var(--to-size) * 2px)) rotateY(calc(var(--dist-factor) * -50deg - 20deg));
     animation: spotlight-properties .1s ease-out .15s both, spotlight-fade .55s ease-out both;


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="920" alt="image" src="https://github.com/user-attachments/assets/d49c125e-5714-48a2-a0bf-03c09c88bc6b" /> | <img width="920" alt="image" src="https://github.com/user-attachments/assets/9558957e-4249-4114-8c98-c4d199959384" /> |
| <img width="420" alt="image" src="https://github.com/user-attachments/assets/56100145-a04f-47bb-ac07-3e25a042dea1" /> | <img width="420" alt="image" src="https://github.com/user-attachments/assets/8a40eec8-2090-4f9e-ac1c-c3f5bb0dc314" /> |

~~`color-mix` is used since custom themes are stored as hex.~~

~~I haven't actually tried building with these changes, but when using the DevTools it looks correct.~~