### PR TITLE
feat: add Catppuccin and Dracula themes & rename default theme

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -175,25 +175,25 @@
 }
 
 .theme-catppuccin {
-  --background: hsl(240 22.7% 8.6%);
-  --foreground: hsl(226.2 63.9% 88%);
-  --muted: hsl(240 21.1% 14.9%);
-  --muted-foreground: hsl(227.6 23.6% 71.8%);
-  --popover: hsl(240 21.1% 14.9%);
-  --popover-foreground: hsl(226.2 63.9% 88%);
-  --card: hsl(240 21.1% 14.9%);
-  --card-foreground: hsl(226.2 63.9% 88%);
-  --border: hsl(234.3 13.2% 31.2%);
-  --input: hsl(234.3 13.2% 31.2%);
-  --primary: hsl(23 92% 75.5%);
-  --primary-foreground: hsl(240 22.7% 8.6%);
-  --secondary: hsl(234.3 13.2% 31.2%);
-  --secondary-foreground: hsl(226.7 35.3% 80%);
-  --accent: hsl(240 21.3% 12%);
-  --accent-foreground: hsl(226.2 63.9% 88%);
-  --destructive: hsl(343.3 81.2% 74.9%);
-  --destructive-foreground: hsl(240 22.7% 8.6%);
-  --ring: hsl(227.6 23.6% 71.8%);
+  --background: hsl(240 21% 15%);
+  --foreground: hsl(226 64% 88%);
+  --muted: hsl(240 23% 9%);
+  --muted-foreground: hsl(228 24% 72%);
+  --popover: hsl(240 23% 9%);
+  --popover-foreground: hsl(226 64% 88%);
+  --card: hsl(240 23% 9%);
+  --card-foreground: hsl(226 64% 88%);
+  --border: hsl(234 13% 31%);
+  --input: hsl(234 13% 31%);
+  --primary: hsl(23 92% 75%);
+  --primary-foreground: hsl(240 23% 9%);
+  --secondary: hsl(234 13% 31%);
+  --secondary-foreground: hsl(226 64% 88%);
+  --accent: hsl(237 16% 23%);
+  --accent-foreground: hsl(226 64% 88%);
+  --destructive: hsl(343 81% 75%);
+  --destructive-foreground: hsl(240 23% 9%);
+  --ring: hsl(231 11% 47%);
 }
 
 .theme-dracula {

--- a/src/app.css
+++ b/src/app.css
@@ -193,7 +193,7 @@
   --accent-foreground: hsl(226 64% 88%);
   --destructive: hsl(343 81% 75%);
   --destructive-foreground: hsl(240 23% 9%);
-  --ring: hsl(231 11% 47%);
+  --ring: hsl(23 92% 75%);
 }
 
 .theme-dracula {
@@ -209,13 +209,13 @@
   --input: hsl(232 14% 31%);
   --primary: hsl(265 89% 78%);
   --primary-foreground: hsl(232 14% 11%);
-  --secondary: hsl(231 10% 29%);
+  --secondary: hsl(235 14% 15%);
   --secondary-foreground: hsl(60 30% 96%);
   --accent: hsl(232 14% 31%);
   --accent-foreground: hsl(60 30% 96%);
-  --destructive: hsl(12 71% 54%);
+  --destructive: hsl(6 66% 48%);
   --destructive-foreground: hsl(60 30% 96%);
-  --ring: hsl(225 27% 51%);
+  --ring: hsl(258 61% 60%);
 }
 
 .theme-amber {

--- a/src/app.css
+++ b/src/app.css
@@ -174,48 +174,48 @@
   --ring: hsl(346.6 79.12% 51.18%);
 }
 
-.theme-ocean {
-  --background: hsl(210 15% 2%);
-  --foreground: hsl(0 0% 96%);
-  --muted: hsl(210 15% 6%);
-  --muted-foreground: hsl(0 0% 55%);
-  --popover: hsl(210 15% 6%);
-  --popover-foreground: hsl(0 0% 96%);
-  --card: hsl(210 15% 4%);
-  --card-foreground: hsl(0 0% 96%);
-  --border: hsl(210 15% 12%);
-  --input: hsl(210 15% 18%);
-  --primary: hsl(210 100% 50%);
-  --primary-foreground: hsl(0 0% 98%);
-  --secondary: hsl(210 30% 18%);
-  --secondary-foreground: hsl(0 0% 96%);
-  --accent: hsl(210 30% 10%);
-  --accent-foreground: hsl(210 100% 90%);
-  --destructive: hsl(0 62.8% 30.6%);
-  --destructive-foreground: hsl(0 0% 98%);
-  --ring: hsl(210 100% 50%);
+.theme-catppuccin {
+  --background: hsl(240 22.7% 8.6%);
+  --foreground: hsl(226.2 63.9% 88%);
+  --muted: hsl(240 21.1% 14.9%);
+  --muted-foreground: hsl(227.6 23.6% 71.8%);
+  --popover: hsl(240 21.1% 14.9%);
+  --popover-foreground: hsl(226.2 63.9% 88%);
+  --card: hsl(240 21.1% 14.9%);
+  --card-foreground: hsl(226.2 63.9% 88%);
+  --border: hsl(234.3 13.2% 31.2%);
+  --input: hsl(234.3 13.2% 31.2%);
+  --primary: hsl(23 92% 75.5%);
+  --primary-foreground: hsl(240 22.7% 8.6%);
+  --secondary: hsl(234.3 13.2% 31.2%);
+  --secondary-foreground: hsl(226.7 35.3% 80%);
+  --accent: hsl(240 21.3% 12%);
+  --accent-foreground: hsl(226.2 63.9% 88%);
+  --destructive: hsl(343.3 81.2% 74.9%);
+  --destructive-foreground: hsl(240 22.7% 8.6%);
+  --ring: hsl(227.6 23.6% 71.8%);
 }
 
-.theme-forest {
-  --background: hsl(142 15% 2%);
-  --foreground: hsl(0 0% 96%);
-  --muted: hsl(142 15% 6%);
-  --muted-foreground: hsl(0 0% 55%);
-  --popover: hsl(142 15% 6%);
-  --popover-foreground: hsl(0 0% 96%);
-  --card: hsl(142 15% 4%);
-  --card-foreground: hsl(0 0% 96%);
-  --border: hsl(142 15% 12%);
-  --input: hsl(142 15% 18%);
-  --primary: hsl(142 70% 45%);
-  --primary-foreground: hsl(0 0% 98%);
-  --secondary: hsl(142 30% 18%);
-  --secondary-foreground: hsl(0 0% 96%);
-  --accent: hsl(142 30% 10%);
-  --accent-foreground: hsl(142 70% 90%);
-  --destructive: hsl(0 62.8% 30.6%);
-  --destructive-foreground: hsl(0 0% 98%);
-  --ring: hsl(142 70% 45%);
+.theme-dracula {
+  --background: hsl(231 15% 18%);
+  --foreground: hsl(60 30% 96%);
+  --muted: hsl(225 15% 24%);
+  --muted-foreground: hsl(225 27% 51%);
+  --popover: hsl(225 15% 24%);
+  --popover-foreground: hsl(60 30% 96%);
+  --card: hsl(225 15% 24%);
+  --card-foreground: hsl(60 30% 96%);
+  --border: hsl(232 14% 31%);
+  --input: hsl(232 14% 31%);
+  --primary: hsl(265 89% 78%);
+  --primary-foreground: hsl(232 14% 11%);
+  --secondary: hsl(231 10% 29%);
+  --secondary-foreground: hsl(60 30% 96%);
+  --accent: hsl(232 14% 31%);
+  --accent-foreground: hsl(60 30% 96%);
+  --destructive: hsl(12 71% 54%);
+  --destructive-foreground: hsl(60 30% 96%);
+  --ring: hsl(225 27% 51%);
 }
 
 .theme-amber {

--- a/src/lib/modules/settings/defaults.ts
+++ b/src/lib/modules/settings/defaults.ts
@@ -42,7 +42,7 @@ export default {
   androidStorageType: 'cache',
   showHentai: false,
   hideSpoilers: false,
-  theme: 'default' as 'default' | 'rose' | 'ocean' | 'forest' | 'amber' | 'lavender' | 'system' | 'custom',
+  theme: 'default' as 'default' | 'rose' | 'catppuccin' | 'dracula' | 'amber' | 'lavender' | 'system' | 'custom',
   customThemeColors: {
     '--custom-background': '#000000',
     '--custom-foreground': '#fafafa',

--- a/src/routes/app/settings/interface/+page.svelte
+++ b/src/routes/app/settings/interface/+page.svelte
@@ -81,7 +81,7 @@
   }
 
   const themes = [
-    { value: 'default', label: 'OLED' },
+    { value: 'default', label: 'Blackout' },
     { value: 'rose', label: 'Rose' },
     { value: 'catppuccin', label: 'Catppuccin' },
     { value: 'dracula', label: 'Dracula' },

--- a/src/routes/app/settings/interface/+page.svelte
+++ b/src/routes/app/settings/interface/+page.svelte
@@ -81,7 +81,7 @@
   }
 
   const themes = [
-    { value: 'default', label: 'OLED Black' },
+    { value: 'default', label: 'OLED' },
     { value: 'rose', label: 'Rose' },
     { value: 'catppuccin', label: 'Catppuccin' },
     { value: 'dracula', label: 'Dracula' },

--- a/src/routes/app/settings/interface/+page.svelte
+++ b/src/routes/app/settings/interface/+page.svelte
@@ -81,10 +81,10 @@
   }
 
   const themes = [
-    { value: 'default', label: 'Default' },
+    { value: 'default', label: 'OLED Black' },
     { value: 'rose', label: 'Rose' },
-    { value: 'ocean', label: 'Ocean' },
-    { value: 'forest', label: 'Forest' },
+    { value: 'catppuccin', label: 'Catppuccin' },
+    { value: 'dracula', label: 'Dracula' },
     { value: 'amber', label: 'Amber' },
     { value: 'lavender', label: 'Lavender' },
     { value: 'system', label: 'System' },


### PR DESCRIPTION
Added the Catppuccin Mocha and Draula themes by replacing the Ocean and Forest themes, and renamed Default to OLED. I left the Rose theme untouched as that is a good spot for a light theme.

| Catppuccin | Dracula |
| --- | --- |
| <img width="1920" alt="image" src="https://github.com/user-attachments/assets/1cf24ccf-1642-4c1a-98e6-e569a9489890" /> | <img width="1920" alt="image" src="https://github.com/user-attachments/assets/df4c4212-71ee-4725-be64-3bb07de2c336" /> |
| <img width="1920" alt="image" src="https://github.com/user-attachments/assets/2c6d69f4-9efa-49d1-bb11-fb33b3a206ca" /> | <img width="1920" alt="image" src="https://github.com/user-attachments/assets/0d305258-ddcc-4aea-8f8b-95596c0153df" /> |
| <img width="1920" alt="image" src="https://github.com/user-attachments/assets/f8b8b426-d3fb-49a9-acca-88fcb58353be" /> | <img width="1920" alt="image" src="https://github.com/user-attachments/assets/b53dba77-54fc-4274-931c-1fd2d6a8e230" /> |

Renamed Default theme
<img width="420" alt="image" src="https://github.com/user-attachments/assets/672d3dbd-e0b2-431b-a497-bd387879b9be" />

Try them as custom themes:
- [ctp-theme.json](https://github.com/user-attachments/files/28814391/ctp-theme.json)
- [dracula-theme.json](https://github.com/user-attachments/files/28814392/dracula-theme.json)

The Catppuccin colors were taken from their [Palette](https://catppuccin.com/palette/#flavor-mocha).  
The Dracula colors were taken from their [Color Palette](https://draculatheme.com/spec#color-palette), [UI Color Palette](https://draculatheme.com/spec#ui-color-palette), and [Functional Colors](https://draculatheme.com/spec#functional-colors).