### PR TITLE
fix: miniplayer tap handling on iOS

### DIFF
--- a/src/lib/components/ui/player/wrapper.svelte
+++ b/src/lib/components/ui/player/wrapper.svelte
@@ -72,7 +72,7 @@
     $bottom = istop ? '-100vb' : '0px'
     $right = isleft ? '-100vi' : '100%'
     dragging = false
-    if (pointerId && wrapper.hasPointerCapture(pointerId)) wrapper.releasePointerCapture(pointerId)
+    if (pointerId) wrapper.releasePointerCapture(pointerId)
   }
 </script>
 

--- a/src/lib/components/ui/player/wrapper.svelte
+++ b/src/lib/components/ui/player/wrapper.svelte
@@ -72,14 +72,14 @@
     $bottom = istop ? '-100vb' : '0px'
     $right = isleft ? '-100vi' : '100%'
     dragging = false
-    if (pointerId) wrapper.releasePointerCapture(pointerId)
+    if (pointerId && wrapper.hasPointerCapture(pointerId)) wrapper.releasePointerCapture(pointerId)
   }
 </script>
 
 <div class={cn('size-full', isMiniplayer && 'z-[49] absolute top-0 left-0 pointer-events-none cursor-pointer touch-none')}
   bind:this={wrapper}
   on:pointerdown={startDragging}
-  on:pointerup|self={endDragging}
+  on:pointerup={endDragging}
   on:pointermove|self={calculatePosition}
   on:pointerleave|self={endHover}
   on:pointercancel|self={endHover}>


### PR DESCRIPTION
This fixes the miniplayer bug which prevents taps on iOS from being fired thus needing to tap multiple times or tap on a weird specific spot to navigate to the player, The root cause of this was that ```pointerdown``` could start from the video/canvas inside the miniplayer, but ```pointerup``` was only allowed to finish if it came directly from the wrapper itself. On iOS, the release often stays targeted on the inner video/canvas, so the wrapper never got to finish the tap and open the player.

I confirmed this works by testing it locally with safari on both my iPhone and iPad.