### PR TITLE
Improve keyboard navigation on the sidebar

### DIFF
--- a/src/lib/components/ui/sidebar/sidebarlist.svelte
+++ b/src/lib/components/ui/sidebar/sidebarlist.svelte
@@ -49,6 +49,20 @@
   let size: 'default' | 'icon-lg' = 'default'
 
   $: size = ($breakpoints.md ? 'default' : 'icon-lg')
+
+  function topFence (e: KeyboardEvent) {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      e.stopPropagation()
+    }
+  }
+
+  function bottomFence (e: KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      e.stopPropagation()
+    }
+  }
 </script>
 
 <svelte:document bind:visibilityState />
@@ -56,11 +70,11 @@
 <BannerImage class='absolute top-0 left-0 w-14 -z-10 hidden md:block' />
 <Logo class={cn('mb-1 h-10 object-contain px-2.5 hidden md:block text-foreground ml-2 cursor-pointer', isMac && 'mt-3')} on:click={() => goto('/#/app/home')} />
 {#if SUPPORTS.isAndroidTV}
-  <SidebarButton href='/#/app/player' class='hidden md:flex py-0'>
+  <SidebarButton href='/#/app/player' class='hidden md:flex py-0' onkeydown={topFence}>
     <Play size={16} />
   </SidebarButton>
 {/if}
-<SidebarButton href='/#/app/home' class='animated-icon' {size}>
+<SidebarButton href='/#/app/home' class='animated-icon' {size} onkeydown={SUPPORTS.isAndroidTV ? () => {} : topFence}>
   <Home size={18} />
 </SidebarButton>
 <SidebarButton href='/#/app/search' class='animated-icon' {size}>
@@ -142,7 +156,7 @@
 <SidebarButton href='/#/app/settings' class='animated-icon !transition-none' {size}>
   <Bolt size={18} />
 </SidebarButton>
-<SidebarButton href='/#/app/profile' class='hidden md:flex animated-icon' {size}>
+<SidebarButton href='/#/app/profile' class='hidden md:flex animated-icon' {size} onkeydown={bottomFence}>
   <!-- <SidebarButton href='/#/app/profile' class='hidden md:flex py-0 animated-icon'> -->
   {#if $viewer}
     <Avatar.Root class='size-6 rounded-md'>


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/3c97c888-091b-4101-8649-476a5de61446



After:

https://github.com/user-attachments/assets/1042816e-3b16-42aa-99af-67d94f59ade6



Prevents focus bleed between the sidebar navigation and main content.

Fixes an issue where pressing ArrowDown on the bottom-most navigation button (or ArrowUp on the top-most button) allowed focus to bleed into the main content area.

My goal is to eventually address other keyboard navigation issues across the app (like unwanted focus transfer between main content and sidebar when using vertical arrow keys, as well as navigation inside the settings menu and player). However, I’d love to get your feedback on whether this initial approach aligns with the project's standards first.

Thanks for building this app—loving it!
<details><summary>Translated from my broken English. Original description: </summary>
<p>
Prevents focus from bleeding from the bottom most navigation button to the main content after pressing the ArrowDown keyboard button. Vice versa when going up. I'd like to fix other keyboard navigation issues such as focus bleeding from main content to the sidebar even though we only pressed ArrowUp or ArrowDown and not pressing ArrowLeft. Settings menu. the player. But I'd like to know your opinion first on whether I'm doing it with the right approach. Thanks for making this app btw, lovin it!
</p>
</details> 