### PR TITLE
fix: spoiler next unwatched episode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ui",
-	"version": "6.4.569",
+	"version": "6.4.570",
 	"license": "BUSL-1.1",
 	"private": true,
 	"packageManager": "pnpm@10.28.0",

--- a/src/lib/components/EpisodesList.svelte
+++ b/src/lib/components/EpisodesList.svelte
@@ -64,7 +64,7 @@
       {#each getPage(currentPage, episodeList) as { episode, image, title, summary, airingAt, airdate, filler, length, rating, runtime } (episode)}
         {@const watched = _progress >= episode && !completed}
         {@const target = _progress + 1 === episode}
-        {@const spoiler = !watched && !completed && !rewatching && !target && $settings.hideSpoilers}
+        {@const spoiler = !watched && !completed && !rewatching && $settings.hideSpoilers}
         {@const underPoweredSpoiler = spoiler && SUPPORTS.isUnderPowered}
         <div class={!target ? 'px-3 w-full' : 'contents'}>
           <div use:click={() => play(episode)}


### PR DESCRIPTION
A simple one-liner change that makes the next unwatched episode a valid spoiler target.

| Before | After |
| --- | --- |
| <img height="250" alt="image" src="https://github.com/user-attachments/assets/8f98a62d-f7f4-4498-9ba4-6237826d4692" /> | <img height="250" alt="image" src="https://github.com/user-attachments/assets/eea5dab6-c209-4886-9fe5-98360208f946" /> |